### PR TITLE
Enable Travis-CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = packages/tau
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    *tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ installed
 # Misc
 *~
 benchmarks
+
+# Python coverage data
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,62 @@
+branches:
+  except:
+    - gh-pages
+
+git:
+  depth: 99999
+
+sudo: false
+os:
+  - linux
+
+cache:
+    directories:
+        - "$HOME/.cache/pip"
+        - "$HOME/.pyenv"
+
+language: python
+env:
+  - PYENV_VERSION='2.7.9' OS='Ubuntu Precise'
+
+matrix:
+  include:
+    - language: generic
+      os: osx
+      osx_image: xcode7.1 # Corresponds to 10.10.x (Yosemite)
+      env:
+        - PYENV_VERSION='2.7.9' OS='OS X Yosemite'
+    - language: generic
+      os: osx
+      osx_image: xcode7.2 # Corresponds to 10.11.x (El Capitan)
+      env:
+        - PYENV_VERSION='2.7.9' OS='OS X El Capitan'
+
+install:
+  - source .travis/install.sh
+
+script:
+  - python --version
+  - ./build.sh
+  - coverage run runtests
+  - make -C docs
+#  - pylint --rcfile=pylintrc packages/tau # Currently returns with 30 exit code and negative score
+
+after_success:
+  - codecov --env TRAVIS_OS_NAME PYENV_VERSION OS
+
+deploy:
+  provider: script
+  script: .travis/deploy-docs.sh
+  skip_cleanup: true
+  on:
+    branch: master
+    condition: $TRAVIS_OS_NAME = linux &&  $PYENV_VERSION = '2.7.9'
+#    repo: ParaToolsInc/taucmdr # Don't try to deploy on private forks
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/5c68036cc5473aa0490f
+    on_success: change  # options: [always|never|change]
+    on_failure: always
+    on_start: always

--- a/.travis/deploy-docs.sh
+++ b/.travis/deploy-docs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Script to deploy Sphinx documentation to gh-pages branch automatically with Travis-CI
+#
+#set -o pipefail
+#set -o errexit
+#set -o nounset
+set -o verbose
+
+git config user.name "Travis-CI-bot"
+git config user.email "info@paratools.com"
+
+git remote set-url origin https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+
+git fetch origin gh-pages > /dev/null 2>&1 && echo success || echo failure
+git fetch --unshallow ||true
+git branch -a -vvv
+
+export PUSH_FLAGS='--quiet --force'
+export HIDE_TOKEN='> /dev/null 2>&1'
+export COMMIT_MSG="Updated documentation on Travis-CI job $TRAVIS_JOB_NUMBER at commit $TRAVIS_COMMIT"
+make -C docs update-github-pages

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#set -o pipefail
+#set -o errexit
+#set -o verbose
+
+# Install pyenv to globally manage python versions
+# See https://github.com/yyuu/pyenv for further details
+echo "$PYENV_ROOT"
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+if [ ! -x "$PYENV_ROOT/bin/pyenv" ]; then
+    curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
+fi
+
+if [ ! -d "$PYENV_ROOT/.git" ]; then # pyenv install script failed, try manual install
+    git clone --no-checkout -v https://github.com/yyuu/pyenv.git "$HOME/tmp"
+    mv "$HOME/tmp/.git" "$PYENV_ROOT/"
+    rmdir "$HOME/tmp"
+    cd "$PYENV_ROOT"
+    git reset --hard HEAD
+    cd -
+fi
+
+ls -a ~/.pyenv
+ls ~/.pyenv/bin
+
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
+pyenv update ||true
+
+export PYENV_VERSION="${PYENV_VERSION:-2.7.9}"
+pyenv install -s ${PYENV_VERSION}
+pyenv global ${PYENV_VERSION}
+pyenv rehash
+pyenv versions
+pyenv which pip
+
+# Create a clean virtualenv to isolate the environment from Travis-CI defaults
+python -m pip install --user virtualenv
+python -m virtualenv "$HOME/.venv"
+source "$HOME/.venv/bin/activate"
+
+# Install development requirements enumerated in requirements.txt
+pip install -r requirements.txt
+
+export PATH="$PWD/bin:$PATH"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,8 +10,14 @@
 #
 HERE := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-LOCAL_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+# Travis-CI tests pushed commits in a detatched head state. As a result,
+# `git rev-parse --abbrev-ref HEAD` won't always be meaningful. If the
+# environment variable TRAVIS_COMMIT is defined, then use this. If not,
+# then use `git rev-parse` (and assume we're on master).
+TRAVIS_COMMIT ?= $(shell git rev-parse --abbrev-ref HEAD)
+LOCAL_BRANCH := $(TRAVIS_COMMIT)
 DOCS_BRANCH = gh-pages
+COMMIT_MSG ?= "Update documentation on $(DOCS_BRANCH) via Makefile"
 
 SPHINX_BUILDER = html
 PROJECT_PACKAGE = tau
@@ -42,12 +48,12 @@ $(PACKAGE_REST_FILE): $(SOURCE_FILES)
 update-github-pages: 
 	git checkout $(DOCS_BRANCH)
 	git checkout $(LOCAL_BRANCH) $(PROJECT_DIR) $(HERE)
-	git rm -f .gitignore
+	-git rm -f .gitignore
 	$(MAKE) all
 	git add $(HERE)
 	git add -u $(HERE)
-	git commit -m "Update documentation on $(DOCS_BRANCH) via Makefile"
-	git push
+	git commit -m $(COMMIT_MSG) # Override on Travis-CI w/ environment var.
+	git push $(PUSH_FLAGS) origin $(DOCS-BRANCH) $(HIDE_TOKEN)
 	git checkout $(LOCAL_BRANCH)
 
 clean:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+codecov==1.6.3
+coverage==4.0.3
+cx-Freeze==4.3.4
+pylint==1.4.4
+sphinx==1.3.6


### PR DESCRIPTION
- Run the following tests and unit tests on:
  - Ubunut Precise (12.04)
  - OS X Yosemite (10.10)
  - OS X El Capitan (10.11)
- Use pyenv to specify python version. Currently using 2.7.9, but
  the test matrix can be expanded to other 2.7.x or even 2.6.x
  pythons
- Unit tests
- Test functionality of `build.sh`
- Test functionality of `make -C docs`
- Upload coverage data to codecov.io
- Automatically build and deploy Sphinx documentation when changes are merged
  into master
